### PR TITLE
link to last setup jaxrs page: 1.5.X instead of legacy 1.3.X

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -8,7 +8,7 @@ Technically speaking - Swagger is a [formal specification](specification) surrou
 
 If you're an API provider and want to use Swagger to describe your APIs - there are several approaches available:
 - A top-down approach where you would use the [Swagger Editor](http://editor.swagger.io) to create your Swagger definition and the use the integrated [Swagger Codegen](swagger-codegen) tools to generate server implementation.
-- A bottom-up approach where you have an existing REST API for which you want to create a Swagger definition. Either you create the definition manually (using the same Swagger Editor mentioned above), or if you are using one of the supported frameworks (JAX-RS, node.js, etc), you can get the Swagger definition generated automatically for you. If you're doing JAX-RS have a look at the example at https://github.com/swagger-api/swagger-core/wiki/Swagger-Core-JAX-RS-Project-Setup.
+- A bottom-up approach where you have an existing REST API for which you want to create a Swagger definition. Either you create the definition manually (using the same Swagger Editor mentioned above), or if you are using one of the supported frameworks (JAX-RS, node.js, etc), you can get the Swagger definition generated automatically for you. If you're doing JAX-RS have a look at the example at https://github.com/swagger-api/swagger-core/wiki/Swagger-Core-JAX-RS-Project-Setup-1.5.X.
 
 If on the other hand you're an API Consumer who wants to integrate with an API that has a Swagger definition you can use the online version of the [Swagger UI](http://petstore.swagger.io/) to explore the API (given that you have a URL to the APIs Swagger definition) - and then use [Swagger Codegen](swagger-codegen) to generate the client library of your choice.
 


### PR DESCRIPTION
I was disappointed when I finally discover after some time that an up to date but not linked documentation exists to [setup swagger 1.5.x](https://github.com/swagger-api/swagger-core/wiki/Swagger-Core-JAX-RS-Project-Setup-1.5.X).
This pull request only does one thing: update link url to last version of the documentation.

This defect can also be seen on the [README.md of swagger-core](https://github.com/swagger-api/swagger-core).