### PR TITLE
List ruby-swagger

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -121,6 +121,7 @@ Name | Description
 [Apivore](https://github.com/westfieldlabs/apivore) | RSpec based tool to test your API against its Swagger 2.0 specification.
 [swagger-blocks](https://github.com/fotinakis/swagger-blocks) | Define and serve live-updating Swagger JSON for Ruby apps.
 [swagger_engine](https://github.com/batdevis/swagger_engine) | include [Swagger-ui](https://github.com/swagger-api/swagger-ui) as mountable rails engine.
+[ruby-swagger](https://github.com/Gild/ruby-swagger) | Generic Swagger 2.0 implementation with support of data extraction for Grape APIs.
 
 #### Scala
 


### PR DESCRIPTION
List Ruby-Swagger (https://github.com/Gild/ruby-swagger), a simple library supporting Swagger 2.0 spec + data extraction from Grape API framework.
