### PR TITLE
Add php-swaggerize-fastroute-library to listed PHP swagger integration

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -104,6 +104,7 @@ Name | Description
 ---|---
 [Swagger-PHP](https://packagist.org/packages/zircote/swagger-php) | a library implementing the swagger.io specification to describe web services, operations/actions and models enabling a uniform means of producing, consuming, and visualizing RESTful web services.
 [SwaggerAssertions](https://github.com/Maks3w/SwaggerAssertions) | Swagger 2 test assertions for validate your API requests and responses
+[php-swaggerize-fastroute-library](https://packagist.org/packages/iadvize/php-swaggerize-fastroute-library#0.2.0) | a package to automatically generate FastRoute from swagger json definition. It's compatible with Lumen as long as you use controller class
 
 #### Python
 
@@ -231,7 +232,6 @@ Name | Description
 [Restler](https://github.com/Luracast/Restler) | PHP framework, swagger support in 3.0.
 [swagger-assert](https://github.com/gong023/swagger-assert) | enable to assert keys in swagger document and API response
 [Swaggervel](https://packagist.org/packages/jlapp/swaggervel) | a package for Laravel that uses Swagger-PHP and swagger-ui to auto-generate docs for your project.
-[php-swaggerize-fastroute-library](https://packagist.org/packages/iadvize/php-swaggerize-fastroute-library#0.2.0) | a package to automatically generate FastRoute from swagger json definition. It's compatible with Lumen as long as you use controller class
 
 #### Python
 

--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -231,6 +231,7 @@ Name | Description
 [Restler](https://github.com/Luracast/Restler) | PHP framework, swagger support in 3.0.
 [swagger-assert](https://github.com/gong023/swagger-assert) | enable to assert keys in swagger document and API response
 [Swaggervel](https://packagist.org/packages/jlapp/swaggervel) | a package for Laravel that uses Swagger-PHP and swagger-ui to auto-generate docs for your project.
+[php-swaggerize-fastroute-library](https://packagist.org/packages/iadvize/php-swaggerize-fastroute-library#0.2.0) | a package to automatically generate FastRoute from swagger json definition. It's compatible with Lumen as long as you use controller class
 
 #### Python
 


### PR DESCRIPTION
I've written a small library to create automatically FastRoute routes from a swagger JSON file, please add reference to your documentation