### PR TITLE
Add a "Community-Driven Tool"

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -267,3 +267,4 @@ Name | Description
 [gform-admin](https://github.com/stemey/gform-admin) | An alternative UI client for Swagger.
 [swagger-cli-client](https://github.com/signalfx/swagger-cli-client) | Command-line interface generator to communicate with Swagger servers.
 [Swagger2Postman](https://github.com/josephpconley/swagger2postman) | Creates a [Postman](http://www.getpostman.com) collection from live Swagger documentation
+[ember-swagger-ui](https://github.com/rynam0/ember-swagger-ui) | An [ember-cli](http://www.ember-cli.com) addon for quickly and easily adding [swagger-ui](https://github.com/swagger-api/swagger-ui) to your [EmberJS](http://emberjs.com/) application.


### PR DESCRIPTION
Added ember-swagger-ui ember-cli addon to the list of "Community-Driven Tools"