### PR TITLE
add `binder-swagger-java` to swagger's community-driven tool list

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -52,6 +52,7 @@ Name | Description
 Name | Description
 ---|---
 [assertj-swagger](https://github.com/RobWin/assertj-swagger) | assertj-swagger is a library which compares a design-first Swagger YAML with an implementation-first Swagger JSON output (e.g. from springfox). assertj-swagger allows to validate that the implementation in compliance with the design specification.
+[binder-swagger-java](https://github.com/tminglei/binder-swagger-java) | binder-swagger-java was designed to help construct the swagger object, corresponding to swagger.json, and let it accessible from swagger ui or other http visitors.
 [dropwizard-swagger](https://github.com/federecio/dropwizard-swagger) | A dropwizard bundle that wraps Swagger-Core.
 [restlet-framework](http://restlet.com/technical-resources/restlet-framework/guide/2.3/extensions/swagger) | Restlet Framework extension that supports auto-generation of Swagger 2.0 from Restlet API and JAX-API applications
 [springfox](https://springfox.github.io/springfox) | Integrates with Spring MVC with support for Swagger 1.2 and Swagger 2.0 spec.


### PR DESCRIPTION
Hi,

I'd like to add `binder-swagger-java`, a tool developed by me, to swagger's community-driven tool list.
Pls help check and give your suggestions.

Thanks!
Minglei Tu