### PR TITLE
 Added "hippie-swagger" to the "Community-Driven Tools" section

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -80,6 +80,7 @@ Name | Description
 Name | Description
 ---|---
 [hapi-swaggered](https://github.com/z0mt3c/hapi-swaggered) | A hapi.js plugin to generate swagger v2.0 compliant specifications based on hapi routes and joi schemas.
+[hippie-swagger](https://github.com/cachecontrol/hippie-swagger) | API testing tool with automatic swagger assertions
 [swaggerize-express](https://github.com/krakenjs/swaggerize-express) | Design-driven RESTful apis with swagger and express from [@PayPalDev](https://twitter.com/PayPalDev).
 [swaggerize-hapi](https://github.com/krakenjs/swaggerize-hapi) | Design-driven RESTful apis with swagger and hapi from [@PayPalDev](https://twitter.com/PayPalDev).
 [generator-swaggerize](https://github.com/krakenjs/generator-swaggerize) | Yeoman generator for krakenjs/swaggerize tools from [@PayPalDev](https://twitter.com/PayPalDev).


### PR DESCRIPTION
Added "hippie-swagger" to the list of "Community-Driven Tools".

Compatible with swagger 2.0