### PR TITLE
Added linter-swagger to open-source.md

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -271,3 +271,4 @@ Name | Description
 [gform-admin](https://github.com/stemey/gform-admin) | An alternative UI client for Swagger.
 [swagger-cli-client](https://github.com/signalfx/swagger-cli-client) | Command-line interface generator to communicate with Swagger servers.
 [Swagger2Postman](https://github.com/josephpconley/swagger2postman) | Creates a [Postman](http://www.getpostman.com) collection from live Swagger documentation
+[linter-swagger](https://atom.io/packages/linter-swagger) | [Atom](https://atom.io) Package for linting Swagger spec

--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -151,6 +151,7 @@ Name | Description
 [swagger-diff](https://github.com/civisanalytics/swagger-diff) | A command-line utility, RSpec matcher, and Ruby library for comparing two Swagger specifications.
 [swagger.ed](https://github.com/chefArchitect/apispots-browser-swaggered) | A Chrome extenstion that will change the way you look at APIs.
 [ember-swagger-ui](https://github.com/rynam0/ember-swagger-ui) | An [ember-cli](http://www.ember-cli.com) addon for quickly and easily adding [swagger-ui](https://github.com/swagger-api/swagger-ui) to your [EmberJS](http://emberjs.com/) application.
+[linter-swagger](https://atom.io/packages/linter-swagger) | [Atom](https://atom.io) Package for linting Swagger spec
 
 ### Tools for previous Swagger versions
 
@@ -271,4 +272,3 @@ Name | Description
 [gform-admin](https://github.com/stemey/gform-admin) | An alternative UI client for Swagger.
 [swagger-cli-client](https://github.com/signalfx/swagger-cli-client) | Command-line interface generator to communicate with Swagger servers.
 [Swagger2Postman](https://github.com/josephpconley/swagger2postman) | Creates a [Postman](http://www.getpostman.com) collection from live Swagger documentation
-[linter-swagger](https://atom.io/packages/linter-swagger) | [Atom](https://atom.io) Package for linting Swagger spec


### PR DESCRIPTION
Added linter-swagger a package for atom.io that "lints" swagger specs, by leveraging swagger-parser, among the other list of projects.