### PR TITLE
Adding express-openapi

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -94,6 +94,7 @@ Name | Description
 
 Name | Description
 ---|---
+[express-openapi](https://github.com/kogosoftwarellc/express-openapi) | Effortlessly add routes and middleware to express apps with openapi documents.
 [hapi-swaggered](https://github.com/z0mt3c/hapi-swaggered) | A hapi.js plugin to generate swagger v2.0 compliant specifications based on hapi routes and joi schemas.
 [fleek-router](https://github.com/fleekjs/fleek-router) | A simple router integrated of swagger with Koa.js
 [fleek-validator](https://github.com/fleekjs/fleek-validator) | A simple validator integrated with swagger on top of Koa.js


### PR DESCRIPTION
Would it be possible to add [express-openapi](https://github.com/kogosoftwarellc/express-openapi) to the `Node.js` section?  I listed it alphabetically.

Thank you for allowing community contributions.