### PR TITLE
Added svelte gem to docs

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -169,6 +169,7 @@ Name | Description
 [Apivore](https://github.com/westfieldlabs/apivore) | RSpec based tool to test your API against its Swagger 2.0 specification.
 [swagger-blocks](https://github.com/fotinakis/swagger-blocks) | Define and serve live-updating Swagger JSON for Ruby apps.
 [swagger_engine](https://github.com/batdevis/swagger_engine) | include [Swagger-ui](https://github.com/swagger-api/swagger-ui) as mountable rails engine.
+[svelte](https://github.com/notonthehighstreet/svelte) | Dynamic Ruby client generator for Swagger 2.0 compliant APIs.
 
 #### Scala
 


### PR DESCRIPTION
Svelte is a ruby gem that generates dynamic clients for Swagger 2 compliant APIs. A link and description to it has been added in the community driven opensource tools.