### PR TITLE
Fix docker port forwarding

### DIFF
--- a/tools-documentation/documentation.md
+++ b/tools-documentation/documentation.md
@@ -52,7 +52,7 @@ Please run the following to run the Editor in your local machine from Docker.
 
 ```
 docker pull swaggerapi/swagger-editor
-docker run -p 80:8080 swaggerapi/swagger-editor
+docker run -p 8080:8080 swaggerapi/swagger-editor
 ```
 
 ### Contribute


### PR DESCRIPTION
The documentation points out that you should forward from 8080 to 80, but the editor is not really working with these settings.
With port 8080 to 8080 it works perfect.