### PR TITLE
Updated open source tool

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -247,7 +247,7 @@ Name | Description
 [Dredd](https://github.com/apiaryio/dredd) | Language-agnostic command-line tool for validating Swagger document against backend implementation of the API.
 [ember-swagger-ui](https://github.com/rynam0/ember-swagger-ui) | An [ember-cli](http://www.ember-cli.com) addon for quickly and easily adding [swagger-ui](https://github.com/swagger-api/swagger-ui) to your [EmberJS](http://emberjs.com/) application.
 [generator-openapi-repo](https://github.com/Rebilly/generator-openapi-repo) | [Yeoman](http://yeoman.io/) generator to setup GitHub repo with spec, documentation ([ReDoc](https://github.com/Rebilly/ReDoc) + [swagger-ui](https://github.com/swagger-api/swagger-ui)) and live-editing with [swagger-editor](https://github.com/swagger-api/swagger-editor).
-[intellij-swagger](https://github.com/zalando/intellij-swagger) | [Swagger Plugin](https://plugins.jetbrains.com/plugin/8347) helps you to easily edit Swagger specification files inside [IntelliJ IDEA](https://www.jetbrains.com/idea)
+[intellij-swagger](https://github.com/zalando/intellij-swagger) | [Swagger Plugin](https://plugins.jetbrains.com/plugin/8347) helps you to easily edit OpenAPI/Swagger specification files inside [IntelliJ IDEA](https://www.jetbrains.com/idea)
 [linter-swagger](https://atom.io/packages/linter-swagger) | [Atom](https://atom.io) Package for linting Swagger spec
 [ReDoc](https://github.com/Rebilly/ReDoc) | OpenAPI/Swagger-generated API Reference Documentation. [Demo](https://rebilly.github.io/ReDoc/)
 [swagger-commander](https://github.com/khangiskhan/swagger-commander) | Plug & play command line interface to Swagger APIs.


### PR DESCRIPTION
intellij-swagger supports OpenAPI, added to the description.