### PR TITLE
Added swagger-stats to node.js section

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -162,6 +162,7 @@ Name | Description
 [Swagger Parser](https://github.com/BigstickCarpet/swagger-parser#swagger-parser) | Parses, validates, and dereferences JSON/YAML Swagger specs in Node and browsers
 [test2doc.js](https://github.com/stackia/test2doc.js) | Autogenerate Swagger specification from your tests/specs.
 [koa-joi-swagger](https://github.com/zaaack/koa-joi-swagger) | Using joi schema to validate and generate Swagger UI, for koa.
+[swagger-stats](https://github.com/slanatech/swagger-stats)|API Telemetry based on Swagger(OpenAPI) specification. Trace API calls and Monitor API performance, health and usage statistics in Node.js Microservices 
 
 #### Perl
 


### PR DESCRIPTION
Propose to add [swagger-stats](https://github.com/slanatech/swagger-stats) to node.js open source integrations.