### PR TITLE
Fixed link pointing to an unknown page.

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -2,7 +2,7 @@
 
 The goal of Swagger™ is to define a standard, language-agnostic interface to REST APIs which allows both humans and computers to discover and understand the capabilities of the service without access to source code, documentation, or through network traffic inspection. When properly defined via Swagger, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interfaces have done for lower-level programming, Swagger removes the guesswork in calling the service.
 
-Technically speaking - Swagger is a [formal specification](specification) surrounded by a large ecosystem of [tools](/tools), which includes everything from front-end user interfaces, low-level code libraries and commercial API management solutions.
+Technically speaking - Swagger is a [formal specification](https://swagger.io/specification/) surrounded by a large ecosystem of [tools](/tools), which includes everything from front-end user interfaces, low-level code libraries and commercial API management solutions.
 
 ## How do I get started?
 


### PR DESCRIPTION
The "formal specification" link pointed to a page that does not exist. I changed it to what I think it was intended to point to.