### PR TITLE
Fix broken link

### DIFF
--- a/docs/spec-explained/index.md
+++ b/docs/spec-explained/index.md
@@ -10,7 +10,7 @@
 * [File Upload](file-upload.md)
 * [Describing Responses](responses.md)
 * [Authentication](authentication/index.md)
-  * [Basic Authentication](authentication/basic.md)
+  * [Basic Authentication](authentication/basic-authentication.md)
   * [API Keys](authentication/api-keys.md)
   * [OAuth 2](authentication/oauth2.md)
 * [Adding Examples](examples.md)


### PR DESCRIPTION
It seems like there was a [typo][1] in abac224 as `authentication/basic.md` was never created, but `authentication/basic-authentication.md` instead actually was.

[1]: https://github.com/swagger-api/swagger.io/commit/abac224f31caa3628f89e302f30e25cfb9b80c4d#diff-1ff03cb692d5c332d2ed87b460082ad6R13