### PR TITLE
Fix reusing responses example

### DIFF
--- a/docs/spec-explained/responses.md
+++ b/docs/spec-explained/responses.md
@@ -228,7 +228,7 @@ paths:
   /users:
     get:
       summary: Gets a list of users.
-      response:
+      responses:
         200:
           description: OK
           schema:
@@ -238,7 +238,7 @@ paths:
   /users/{id}:
     get:
       summary: Gets a user by ID.
-      response:
+      responses:
         200:
           description: OK
           schema:


### PR DESCRIPTION
The example in for re-using responses is invalid. This fix renames 'response' to 'responses'.