### PR TITLE
Add R section. Add `plumber` and `swagger`

### DIFF
--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -251,7 +251,7 @@ Name | Description
 Name | Description
 ---|---
 [plumber](https://github.com/rstudio/plumber) | Create an API powered by the R language whose default OpenAPI documentation is served by `swagger`.
-[swagger](https://github.com/rstudio/swagger) | Dynamically Generate Documentation from a 'Swagger' Compliant R API
+[swagger](https://github.com/rstudio/swagger) | Dynamically Generate Documentation from a 'Swagger' Compliant R API.
 
 #### Ruby
 

--- a/integrations/open-source.md
+++ b/integrations/open-source.md
@@ -246,6 +246,13 @@ Name | Description
 [swagger-to](https://github.com/Parquery/swagger-to) | `swagger-to` generates Python client code with type annotations (based on `requests`) from a Swagger spec.
 
 
+#### R
+
+Name | Description
+---|---
+[plumber](https://github.com/rstudio/plumber) | Create an API powered by the R language whose default OpenAPI documentation is served by `swagger`.
+[swagger](https://github.com/rstudio/swagger) | Dynamically Generate Documentation from a 'Swagger' Compliant R API
+
 #### Ruby
 
 Name | Description


### PR DESCRIPTION
Plumber has a full website, https://www.rplumber.io/ , but it seemed like each link was pointing to the relevant GitHub repo.

Thank you!