### PR TITLE
Add example for getting map of all header values as parameter

### DIFF
--- a/docs/spec-explained/parameters.md
+++ b/docs/spec-explained/parameters.md
@@ -117,6 +117,22 @@ paths:
           required: true
 ```
 
+Or, you would get all headers within a map as follows:
+
+```
+paths:
+  /ping:
+    get:
+      summary: Checks if the server is alive.
+      parameters:
+        - in: header
+          name: headers
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+```
+
 In a similar way, you can define [custom response headers](#header-parameters).
 
 **Note:** Swagger specification has special keywords for some headers:


### PR DESCRIPTION
Hi, I have spent so much time browsing the internet to find a way how to get all headers as a map via Swagger Openapi. Unfortunately, I found nothing so far. 

I tried one of our endpoint definitions where we get a map as a request parameter. I have just changed the name value with the `headers` keyword, and it worked!

Thus, I wanted the documentation to be updated with this additional example, to prevent people from wasting so much time like me.